### PR TITLE
Stopped recreation of sprites

### DIFF
--- a/TouchBarVisualizer/ColorScene.swift
+++ b/TouchBarVisualizer/ColorScene.swift
@@ -24,29 +24,6 @@ class ColorScene: SKScene {
 	override func didMove(to view: SKView) { // Initialize all sprites for leveling
 		print(self.size.width)
 		self.backgroundColor = .black
-		for i in 0...99 {
-			var popul : [SKSpriteNode] = []
-			for c in 0...10 { // 10,9 / 8,7
-				var color : NSColor!
-				if c < 5 {
-					color = .green
-				} else if c < 8 {
-					color = .orange
-				} else {
-					color = .red
-				}
-				let x : CGFloat = (wid * CGFloat(i + 1)) // 110 aprox escape key distance
-				let texture = SKTexture(imageNamed: "square")
-				
-				let rect = SKSpriteNode(texture: texture, color: color, size: CGSize(width: wid, height: 3))
-				rect.colorBlendFactor = 1.0
-				self.addChild(rect)
-				rect.position = CGPoint(x: x, y: (rect.size.height * CGFloat(c - 1)) + (rect.size.height / 2))
-				
-				popul.append(rect)
-			}
-			allNodes.append(popul)
-		}
 		
 		if !ready {
 			self.backgroundColor = .black
@@ -54,6 +31,30 @@ class ColorScene: SKScene {
 		}
 		
 		if !created {
+			for i in 0...99 {
+				var popul : [SKSpriteNode] = []
+				for c in 0...10 { // 10,9 / 8,7
+					var color : NSColor!
+					if c < 5 {
+						color = .green
+					} else if c < 8 {
+						color = .orange
+					} else {
+						color = .red
+					}
+					let x : CGFloat = (wid * CGFloat(i + 1)) // 110 aprox escape key distance
+					let texture = SKTexture(imageNamed: "square")
+					
+					let rect = SKSpriteNode(texture: texture, color: color, size: CGSize(width: wid, height: 3))
+					rect.colorBlendFactor = 1.0
+					self.addChild(rect)
+					rect.position = CGPoint(x: x, y: (rect.size.height * CGFloat(c - 1)) + (rect.size.height / 2))
+					
+					popul.append(rect)
+				}
+				allNodes.append(popul)
+			}
+			
 			NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(appChange(_:)), name: NSWorkspace.didActivateApplicationNotification, object: nil)
 			created = true
 			moveCent() //Correct call point?
@@ -85,12 +86,12 @@ class ColorScene: SKScene {
 		print(app.localizedName!) // track changes
 		if "TouchBarVisualizer" == app.localizedName {
 			active = true
-			print(app.localizedName!, 0)
+			print("Changed to TBV")
 			moveAJ()
 		} else {
 			active = false
 			moveCent()
-			print(app.localizedName!, 1)
+			print("Changed to external")
 		}
 	}
 	

--- a/TouchBarVisualizer/ViewController.swift
+++ b/TouchBarVisualizer/ViewController.swift
@@ -29,11 +29,6 @@ class ViewController: NSViewController {
 	
 	@IBOutlet var levelDisplay: NSLevelIndicator!
 	
-//	@IBAction func show(_ sender: Any) {
-//		stop()
-//		newAuds.destroyAggDevice()
-//	}
-	
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		createAudioDevice()

--- a/TouchBarVisualizer/ViewController.swift
+++ b/TouchBarVisualizer/ViewController.swift
@@ -176,7 +176,6 @@ extension ViewController: NSTouchBarDelegate {
 	}
 	
 	func touchBar(_ touchBar: NSTouchBar, makeItemForIdentifier identifier: NSTouchBarItem.Identifier) -> NSTouchBarItem? {
-		
 		let item = NSCustomTouchBarItem(identifier: itemID)
 		colorSKView = ColorView()
 		item.view = colorSKView
@@ -187,7 +186,8 @@ extension ViewController: NSTouchBarDelegate {
 	}
 
 	func presentSystemModal(_ touchBar: NSTouchBar!, systemTrayItemIdentifier identifier: NSTouchBarItem.Identifier!) {
-		NSTouchBar.presentSystemModalTouchBar(touchBar, systemTrayItemIdentifier: identifier)	}
+		NSTouchBar.presentSystemModalTouchBar(touchBar, systemTrayItemIdentifier: identifier)
+	}
 
 	func presentSystemModal(_ touchBar: NSTouchBar!, placement: Int64, systemTrayItemIdentifier identifier: NSTouchBarItem.Identifier!) {
 		NSTouchBar.presentSystemModalTouchBar(touchBar, placement: placement, systemTrayItemIdentifier: identifier)


### PR DESCRIPTION
Somehow during the original development I brought out code for creating the sprites from under its `if` statement. I have moved it back to the original place I had intended it to be under. This resolves #2 and it turned out that the audio stream was not in fact the reasons for the glowing screen but instead a single if statement.